### PR TITLE
1.19.0 fix

### DIFF
--- a/NoFailCheck/HarmonyPatches/StandardLevelDetailViewControllerPatches.cs
+++ b/NoFailCheck/HarmonyPatches/StandardLevelDetailViewControllerPatches.cs
@@ -12,14 +12,13 @@ namespace NoFailCheck.HarmonyPatches
         typeof(bool),
         typeof(bool),
         typeof(bool),
-        typeof(bool),
         typeof(string),
         typeof(BeatmapDifficultyMask),
         typeof(BeatmapCharacteristicSO[])
     })]
     class StandardLevelDetailViewControllerPatches
     {
-        static bool Prefix(IBeatmapLevelPack pack, IPreviewBeatmapLevel previewBeatmapLevel, bool showPlayerStats, bool hidePracticeButton, bool hide360DegreeBeatmapCharacteristic, bool canBuyPack, ref string playButtonText, BeatmapDifficultyMask allowedBeatmapDifficultyMask, BeatmapCharacteristicSO[] notAllowedCharacteristics)
+        static bool Prefix(IBeatmapLevelPack pack, IPreviewBeatmapLevel previewBeatmapLevel, bool hidePracticeButton, bool hide360DegreeBeatmapCharacteristic, bool canBuyPack, ref string playButtonText, BeatmapDifficultyMask allowedBeatmapDifficultyMask, BeatmapCharacteristicSO[] notAllowedCharacteristics)
         {
             if (Plugin.cfg.Enabled && NoFailCheck.IsInSoloFreeplay)
             {

--- a/NoFailCheck/Plugin.cs
+++ b/NoFailCheck/Plugin.cs
@@ -58,7 +58,7 @@ namespace NoFailCheck
         [OnExit]
         public void OnExit()
         {
-            harmony.UnpatchAll("com.nate1280.BeatSaber.NoFailCheck");
+            harmony.UnpatchSelf();
         }
     }
 }

--- a/NoFailCheck/manifest.json
+++ b/NoFailCheck/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nike4613/ModSaber-MetadataFileSchema/master/Schema.json",
   "author": "nate1280",
   "description": "Ever get tired of starting a song with No Fail on, and getting annoyed, let this mod annoy you instead to remind you!",
-  "gameVersion": "1.16.1",
+  "gameVersion": "1.19.0",
   "id": "NoFailCheck",
   "name": "NoFailCheck",
   "version": "1.8.0",


### PR DESCRIPTION
As title, this pr fixes the compatibility with game version 1.19.0.

`UnpatchAll` is obsolete with current harmony lib and `UnpatchSelf` is the new recommended way of unpatch